### PR TITLE
Dropdown menu added to registerWithSchool

### DIFF
--- a/PollBuddy-Server/frontend/package.json
+++ b/PollBuddy-Server/frontend/package.json
@@ -6,6 +6,7 @@
     "mdbreact": "^4.21.1",
     "node-sass": "^4.14.1",
     "react": "^16.10.2",
+    "react-autocomplete": "^1.8.1",
     "react-countdown-now": "^2.1.2",
     "react-dom": "^16.10.2",
     "react-router-dom": "^5.2.0",

--- a/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
+++ b/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
@@ -9,6 +9,11 @@ export default class registerWithSchool extends Component {
     this.props.updateTitle("Register with School");
   }
 
+  constructor(props) {
+    super(props);
+    this.state = { value: "" }
+  }
+
   render() {
     return (
       <MDBContainer fluid className="page">
@@ -25,6 +30,7 @@ export default class registerWithSchool extends Component {
           <MDBContainer className="form-group">
             <Autocomplete
               getItemValue={(item) => item.label}
+              shouldItemRender={(item, value) => item.label.toLowerCase().indexOf(value.toLowerCase()) >= 0}
               items={[
                 { key: 0, label: "Rensselaer Polytechnic Institute" },
                 { key: 1, label: "Worcester Polytechnic Institute" },
@@ -35,27 +41,19 @@ export default class registerWithSchool extends Component {
                 { key: 6, label: "SUNY Albany" },
                 { key: 7, label: "Albany Medical College" }
               ]}
-              /*
-              renderInput={function(props) {
-                return (<input
-                  aria-labelledby="schoolNameText"
-                  placeholder="Enter school name"
-                  className="form-control textBox"
-                  onClick={props.onClick(props.ref)}
-                  onChange={props.onChange(props.ref)}
-                />)
+              inputProps = {{
+                className: "form-control textBox",
+                placeholder: "Enter school name",
+                "aria-labelledby": "schoolNameText"
               }}
-              */
               renderItem={(item, isHighlighted) =>
                 <div key={item.key} style={{ background: isHighlighted ? 'lightgray' : 'white' }}>
                   {item.label}
                 </div>
               }
-              value={""}
-              onChange={(e, value) => value = e.target.value}
-              // onChange={(e, value) => {console.log(value); console.log(e.target.value)}}
-              // these are one and the same
-              // onSelect={(val) => value = val}
+              value={this.state.value}
+              onChange = {e => this.setState({ value: e.target.value })}
+              onSelect={value => this.setState({ value })}
             />
           </MDBContainer>
 

--- a/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
+++ b/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
@@ -23,14 +23,21 @@ export default class registerWithSchool extends Component {
             School Name:
           </p>
           <MDBContainer className="form-group">
-            <input placeholder="Enter school name" className="form-control textBox"/>
             <Autocomplete
               getItemValue={(item) => item.label}
               items={[
-                { label: 'apple' },
-                { label: 'banana' },
-                { label: 'pear' }
+                { label: "Rensselaer Polytechnic Institute" },
+                { label: "Worcester Polytechnic Institute" },
+                { label: "Massachusetts Institute of Technology" },
+                { label: "Rochester Institute of Technology" },
+                { label: "University of Rochester" },
+                { label: "SUNY Polytechnic Institute" },
+                { label: "SUNY Albany" },
+                { label: "Albany Medical College" }
               ]}
+              renderInput={function(props) {
+                return <input placeholder="Enter school name" className="form-control textBox"/>
+              }}
               renderItem={(item, isHighlighted) =>
                 <div style={{ background: isHighlighted ? 'lightgray' : 'white' }}>
                   {item.label}

--- a/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
+++ b/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
@@ -45,7 +45,7 @@ export default class registerWithSchool extends Component {
                 const lowB = itemB.label.toLowerCase();
                 const indexA = lowA.indexOf(value.toLowerCase());
                 const indexB = lowB.indexOf(value.toLowerCase());
-                if(indexA !== indexB) return (indexA - indexB);
+                if(indexA !== indexB) { return (indexA - indexB); }
                 return (lowA < lowB ? -1 : 1);
               }}
               shouldItemRender={(item, value) => item.label.toLowerCase().indexOf(value.toLowerCase()) >= 0}

--- a/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
+++ b/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
@@ -45,7 +45,9 @@ export default class registerWithSchool extends Component {
                 const lowB = itemB.label.toLowerCase();
                 const indexA = lowA.indexOf(value.toLowerCase());
                 const indexB = lowB.indexOf(value.toLowerCase());
-                if(indexA !== indexB) { return (indexA - indexB); }
+                if(indexA !== indexB) {
+                  return (indexA - indexB);
+                }
                 return (lowA < lowB ? -1 : 1);
               }}
               shouldItemRender={(item, value) => item.label.toLowerCase().indexOf(value.toLowerCase()) >= 0}

--- a/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
+++ b/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
@@ -1,4 +1,5 @@
 import React, {Component} from "react";
+import Autocomplete from "react-autocomplete";
 import {MDBContainer} from "mdbreact";
 import "mdbreact/dist/css/mdb.css";
 import {Link} from "react-router-dom";
@@ -23,6 +24,22 @@ export default class registerWithSchool extends Component {
           </p>
           <MDBContainer className="form-group">
             <input placeholder="Enter school name" className="form-control textBox"/>
+            <Autocomplete
+              getItemValue={(item) => item.label}
+              items={[
+                { label: 'apple' },
+                { label: 'banana' },
+                { label: 'pear' }
+              ]}
+              renderItem={(item, isHighlighted) =>
+                <div style={{ background: isHighlighted ? 'lightgray' : 'white' }}>
+                  {item.label}
+                </div>
+              }
+              // value={value}
+              // onChange={(e) => value = e.target.value}
+              // onSelect={(val) => value = val}
+            />
           </MDBContainer>
 
           <Link to={"/accountinfo"}>

--- a/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
+++ b/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
@@ -19,32 +19,42 @@ export default class registerWithSchool extends Component {
           <p className="width-90 fontSizeSmall">
             To create an account, enter your school name or login using RPI's CAS.
           </p>
-          <p className="width-90 fontSizeSmall">
+          <p className="width-90 fontSizeSmall" id="schoolNameText">
             School Name:
           </p>
           <MDBContainer className="form-group">
             <Autocomplete
               getItemValue={(item) => item.label}
               items={[
-                { label: "Rensselaer Polytechnic Institute" },
-                { label: "Worcester Polytechnic Institute" },
-                { label: "Massachusetts Institute of Technology" },
-                { label: "Rochester Institute of Technology" },
-                { label: "University of Rochester" },
-                { label: "SUNY Polytechnic Institute" },
-                { label: "SUNY Albany" },
-                { label: "Albany Medical College" }
+                { key: 0, label: "Rensselaer Polytechnic Institute" },
+                { key: 1, label: "Worcester Polytechnic Institute" },
+                { key: 2, label: "Massachusetts Institute of Technology" },
+                { key: 3, label: "Rochester Institute of Technology" },
+                { key: 4, label: "University of Rochester" },
+                { key: 5, label: "SUNY Polytechnic Institute" },
+                { key: 6, label: "SUNY Albany" },
+                { key: 7, label: "Albany Medical College" }
               ]}
+              /*
               renderInput={function(props) {
-                return <input placeholder="Enter school name" className="form-control textBox"/>
+                return (<input
+                  aria-labelledby="schoolNameText"
+                  placeholder="Enter school name"
+                  className="form-control textBox"
+                  onClick={props.onClick(props.ref)}
+                  onChange={props.onChange(props.ref)}
+                />)
               }}
+              */
               renderItem={(item, isHighlighted) =>
-                <div style={{ background: isHighlighted ? 'lightgray' : 'white' }}>
+                <div key={item.key} style={{ background: isHighlighted ? 'lightgray' : 'white' }}>
                   {item.label}
                 </div>
               }
-              // value={value}
-              // onChange={(e) => value = e.target.value}
+              value={""}
+              onChange={(e, value) => value = e.target.value}
+              // onChange={(e, value) => {console.log(value); console.log(e.target.value)}}
+              // these are one and the same
               // onSelect={(val) => value = val}
             />
           </MDBContainer>
@@ -55,11 +65,10 @@ export default class registerWithSchool extends Component {
 
           <form>
             <button className="btn button"
-              formAction="https://cas-auth.rpi.edu/cas/login?service=http%3A%2F%2Fcms.union.rpi.edu%2Flogin%2Fcas%2F%3Fnext%3Dhttps%253A%252F%252Fwww.google.com%252F">CAS
-              (I'm an RPI student)
+              formAction="https://cas-auth.rpi.edu/cas/login?service=http%3A%2F%2Fcms.union.rpi.edu%2Flogin%2Fcas%2F%3Fnext%3Dhttps%253A%252F%252Fwww.google.com%252F">
+              CAS (I'm an RPI student)
             </button>
           </form>
-
 
         </MDBContainer>
       </MDBContainer>

--- a/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
+++ b/PollBuddy-Server/frontend/src/pages/registerWithSchool/registerWithSchool.js
@@ -27,10 +27,8 @@ export default class registerWithSchool extends Component {
           <p className="width-90 fontSizeSmall" id="schoolNameText">
             School Name:
           </p>
-          <MDBContainer className="form-group">
+          <MDBContainer className="form-group" style={{ width: "100%" }}>
             <Autocomplete
-              getItemValue={(item) => item.label}
-              shouldItemRender={(item, value) => item.label.toLowerCase().indexOf(value.toLowerCase()) >= 0}
               items={[
                 { key: 0, label: "Rensselaer Polytechnic Institute" },
                 { key: 1, label: "Worcester Polytechnic Institute" },
@@ -41,18 +39,38 @@ export default class registerWithSchool extends Component {
                 { key: 6, label: "SUNY Albany" },
                 { key: 7, label: "Albany Medical College" }
               ]}
-              inputProps = {{
-                className: "form-control textBox",
-                placeholder: "Enter school name",
-                "aria-labelledby": "schoolNameText"
+              getItemValue={item => item.label}
+              sortItems={(itemA, itemB, value) => {
+                const lowA = itemA.label.toLowerCase();
+                const lowB = itemB.label.toLowerCase();
+                const indexA = lowA.indexOf(value.toLowerCase());
+                const indexB = lowB.indexOf(value.toLowerCase());
+                if(indexA !== indexB) return (indexA - indexB);
+                return (lowA < lowB ? -1 : 1);
               }}
+              shouldItemRender={(item, value) => item.label.toLowerCase().indexOf(value.toLowerCase()) >= 0}
               renderItem={(item, isHighlighted) =>
-                <div key={item.key} style={{ background: isHighlighted ? 'lightgray' : 'white' }}>
+                <div
+                  key={item.key}
+                  className="fontSizeSmall"
+                  style={{
+                    background: isHighlighted ? "#DFCFEA" : "#FFF",
+                    fontFamily: "monospace",
+                    textAlign: "center"
+                  }}
+                >
                   {item.label}
                 </div>
               }
+              inputProps={{
+                className: "form-control textBox",
+                style: { width: "100%" },
+                placeholder: "Enter school name",
+                "aria-labelledby": "schoolNameText"
+              }}
+              wrapperStyle={{ display: "inline-block", width: "100%"}}
               value={this.state.value}
-              onChange = {e => this.setState({ value: e.target.value })}
+              onChange={e => this.setState({ value: e.target.value })}
               onSelect={value => this.setState({ value })}
             />
           </MDBContainer>


### PR DESCRIPTION
<!-- Thank you for your pull request. Please fill out the items below :) -->

<!-- 
### Things to do before creating a pull request:
1. Make sure that your PR is not a duplicate.
2. You have done your changes in a separate branch that's based on either frontend or backend.
3. You have used descriptive commit messages.
4. You've tested your changes
5. Your pull request should be from your branch into either frontend or backend. 
6. Your pull request should have a descriptive title, and fill out everything below.
7. Assign someone to review this PR, plus the PM
-->

### Description of change(s), including why:

I added a combo-box style input field to the registerWithSchool page to make inputting a school name easier. This was done using what seemed like a well-established npm module called [React Autocomplete](https://www.npmjs.com/package/react-autocomplete). I tried my best to use its props and methods to apply consistent styling and provide a smooth user experience.

### Type of change(s)
<!--- What types of changes does your code introduce? Replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Any work to still do or other concerns:

- Ensure the data transfer of the school name is actually going through
- Actually reflect the supported schools in the data (once that time comes)
- Validate that the input is a real school (again, once that time comes)
- Additional styling may or may not be needed (this is a matter of opinion)

### Closing issues:

- Closes #184 

### Screenshots (if frontend change) of before and after:

_Before:_
![Capture9](https://user-images.githubusercontent.com/43757307/87237119-23347900-c3c0-11ea-91d3-0a170bcb2e63.PNG)

_After (multiple screenshots meant to show filtering in action):_
![Capture5](https://user-images.githubusercontent.com/43757307/87237128-4fe89080-c3c0-11ea-81c8-0f52de3fdd08.PNG)
![Capture6](https://user-images.githubusercontent.com/43757307/87237136-77d7f400-c3c0-11ea-8103-9b7ed48a5ab6.PNG)
![Capture8](https://user-images.githubusercontent.com/43757307/87237138-7e666b80-c3c0-11ea-81b8-8dbed389269b.PNG)
