### PR TITLE
Groups functionality

### DIFF
--- a/PollBuddy-Server/frontend/src/components/LoadingWheel/LoadingWheel.scss
+++ b/PollBuddy-Server/frontend/src/components/LoadingWheel/LoadingWheel.scss
@@ -1,7 +1,7 @@
 ﻿.LoadingWheel-loader{
-  position: relative;
-  top: calc(0em);
-  left: calc(0em);
+  position: absolute;
+  left: 32em;
+  top: 16em;
   width: 6em;
   height: 6em;
   border: 1.1em solid rgba(0, 0, 0, 0.2);
@@ -12,10 +12,10 @@
 }
 
 @keyframes load {
-    0% {
-        transform: rotate(0deg);
-    }
-    100% {
-        transform: rotate(360deg);
-    }
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
 }

--- a/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
+++ b/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
@@ -43,17 +43,15 @@ export default class Groups extends Component {
 
   render() {
     if(this.state.error != null){
-      return <p className="fontSizeLarge">Error! Please try again.</p>
-    }
-    else if(!this.state.doneLoading){
+      return <p className="fontSizeLarge">Error! Please try again.</p>;
+    } else if(!this.state.doneLoading){
       return (
         <MDBContainer>
           <LoadingWheel/>
           <button className="btn button" onClick={this.stopLoading}>End Loading</button>
         </MDBContainer>
       );
-    }
-    else {
+    } else {
       return (
         <MDBContainer className="page">
           <MDBContainer className="box">

--- a/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
+++ b/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
@@ -5,11 +5,24 @@ import { MDBContainer } from "mdbreact";
 export default class Groups extends Component {
   constructor(){
     super();
+    this.state = {
+      admin_classes: [
+        {key: 0, id: 123, label: "CSCI 1200 - Data Structures"},
+        {key: 1, id: 123, label: "CSCI 2200 - FOCS"}
+      ],
+      member_classes: [
+        {key: 0, id: 123, label: "CSCI 2300 - Intro to Algorithms"},
+        {key: 1, id: 123, label: "CSCI 2500 - Computer Organization"},
+        {key: 2, id: 123, label: "CSCI 2960 - RCOS"}
+      ]
+    };
+    
     if(!localStorage.getItem("loggedIn")){
       //Redirect("/login");//this is a way to redirect the user to the page
       //window.location.reload(false);//this forces a reload so this will make the user go to the login page. A little barbaric but it works. If frontend wants to make it better by all means
     }
   }
+
   signout(){
     //localStorage.removeItem("loggedIn");//todo if admin -- more specifically make diff states if the user who logged in is an admin... or teacher. wouldn't want teacher accessing user things or vice versa...
     //Redirect("/login");
@@ -17,7 +30,7 @@ export default class Groups extends Component {
   componentDidMount(){
     this.props.updateTitle("My Groups");
   }
-  render() { 
+  render() {
     return (
 
       <MDBContainer className="page">
@@ -25,25 +38,20 @@ export default class Groups extends Component {
           <p className="fontSizeLarge">
             As a Group Admin:
           </p>
-          <Link to={"/groups/123/edit"}>
-            <button className="btn button">CSCI 1200 - Data Structures</button>
-          </Link>
-          <Link to={"/groups/123/edit"}>
-            <button className="btn button">CSCI 2200 - Foundations of Computer Science</button>
-          </Link>
+          {this.state.admin_classes.map((e) => (
+              <Link to={"/groups/" + e.id + "/polls"}>
+                <button className="btn button">{e.label}</button>
+              </Link>
+          ))}
 
           <p className="fontSizeLarge">
             As a Group Member:
           </p>
-          <Link to={"/groups/123/polls"}>
-            <button className="btn button">CSCI 2300 - Intro to Algorithms</button>
-          </Link>
-          <Link to={"/groups/123/polls"}>
-            <button className="btn button">CSCI 2500 - Computer Organization</button>
-          </Link>
-          <Link to={"/groups/123/polls"}>
-            <button className="btn button">CSCI 2960 - RCOS</button>
-          </Link>
+          {this.state.member_classes.map((e) => (
+              <Link to={"/groups/" + e.id + "/polls"}>
+                <button className="btn button">{e.label}</button>
+              </Link>
+          ))}
 
           <p className="fontSizeLarge">
             Group Management:

--- a/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
+++ b/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
@@ -1,6 +1,7 @@
 import React, {Component} from "react";
 import {Link, Redirect} from "react-router-dom";
 import { MDBContainer } from "mdbreact";
+import LoadingWheel from "../../components/LoadingWheel/LoadingWheel";
 
 function getGroups(){
   return [
@@ -14,6 +15,8 @@ export default class Groups extends Component {
   constructor(){
     super();
     this.state = {
+      error: null,
+      doneLoading: false,
       admin_groups: [
         {key: 0, id: 123, label: "CSCI 1200 - Data Structures"},
         {key: 1, id: 123, label: "CSCI 2200 - Foundations of Computer Science"}
@@ -32,44 +35,63 @@ export default class Groups extends Component {
     }
   }
 
+  stopLoading = e => {
+    this.setState({
+      doneLoading: true
+    });
+  };
+
   signout(){
     //localStorage.removeItem("loggedIn");//todo if admin -- more specifically make diff states if the user who logged in is an admin... or teacher. wouldn't want teacher accessing user things or vice versa...
     //Redirect("/login");
   }
   componentDidMount(){
     this.props.updateTitle("My Groups");
+
   }
   render() {
-    return (
-
-      <MDBContainer className="page">
-        <MDBContainer className="box">
-          <p className="fontSizeLarge">
-            As a Group Admin:
-          </p>
-          {this.state.admin_groups.map((e) => (
-              <Link to={"/groups/" + e.id + "/polls"}>
-                <button className="btn button width-20em">{e.label}</button>
-              </Link>
-          ))}
-
-          <p className="fontSizeLarge">
-            As a Group Member:
-          </p>
-          {this.state.member_groups.map((e) => (
-              <Link to={"/groups/" + e.id + "/polls"}>
-                <button className="btn button width-20em">{e.label}</button>
-              </Link>
-          ))}
-
-          <p className="fontSizeLarge">
-            Group Management:
-          </p>
-          <Link to={"/groups/new"}>
-            <button className="btn button">New Group</button>
-          </Link>
+    if(this.state.error != null){
+      return <p className="fontSizeLarge">Error! Please try again.</p>
+    }
+    else if(!this.state.doneLoading){
+      return (
+        <MDBContainer>
+          <LoadingWheel/>
+          <button className="btn button" onClick={this.stopLoading}>End Loading</button>
         </MDBContainer>
-      </MDBContainer>
-    );
+      );
+    }
+    else {
+      return (
+        <MDBContainer className="page">
+          <MDBContainer className="box">
+            <p className="fontSizeLarge">
+              As a Group Admin:
+            </p>
+            {this.state.admin_groups.map((e) => (
+                <Link to={"/groups/" + e.id + "/polls"}>
+                  <button className="btn button width-20em">{e.label}</button>
+                </Link>
+            ))}
+
+            <p className="fontSizeLarge">
+              As a Group Member:
+            </p>
+            {this.state.member_groups.map((e) => (
+                <Link to={"/groups/" + e.id + "/polls"}>
+                  <button className="btn button width-20em">{e.label}</button>
+                </Link>
+            ))}
+
+            <p className="fontSizeLarge">
+              Group Management:
+            </p>
+            <Link to={"/groups/new"}>
+              <button className="btn button">New Group</button>
+            </Link>
+          </MDBContainer>
+        </MDBContainer>
+      );
+    }
   }
 }

--- a/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
+++ b/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
@@ -2,21 +2,30 @@ import React, {Component} from "react";
 import {Link, Redirect} from "react-router-dom";
 import { MDBContainer } from "mdbreact";
 
+function getGroups(){
+  return [
+    {key: 0, id: 123, label: "CSCI 2300 - Intro to Algorithms"},
+    {key: 1, id: 123, label: "CSCI 2500 - Computer Organization"},
+    {key: 2, id: 123, label: "CSCI 2960 - RCOS"}
+  ]
+}
+
 export default class Groups extends Component {
   constructor(){
     super();
     this.state = {
-      admin_classes: [
+      admin_groups: [
         {key: 0, id: 123, label: "CSCI 1200 - Data Structures"},
-        {key: 1, id: 123, label: "CSCI 2200 - FOCS"}
+        {key: 1, id: 123, label: "CSCI 2200 - Foundations of Computer Science"}
       ],
-      member_classes: [
+      member_groups: [
         {key: 0, id: 123, label: "CSCI 2300 - Intro to Algorithms"},
         {key: 1, id: 123, label: "CSCI 2500 - Computer Organization"},
         {key: 2, id: 123, label: "CSCI 2960 - RCOS"}
-      ]
+      ],
+      all_groups: getGroups()
     };
-    
+
     if(!localStorage.getItem("loggedIn")){
       //Redirect("/login");//this is a way to redirect the user to the page
       //window.location.reload(false);//this forces a reload so this will make the user go to the login page. A little barbaric but it works. If frontend wants to make it better by all means
@@ -38,18 +47,18 @@ export default class Groups extends Component {
           <p className="fontSizeLarge">
             As a Group Admin:
           </p>
-          {this.state.admin_classes.map((e) => (
+          {this.state.admin_groups.map((e) => (
               <Link to={"/groups/" + e.id + "/polls"}>
-                <button className="btn button">{e.label}</button>
+                <button className="btn button width-20em">{e.label}</button>
               </Link>
           ))}
 
           <p className="fontSizeLarge">
             As a Group Member:
           </p>
-          {this.state.member_classes.map((e) => (
+          {this.state.member_groups.map((e) => (
               <Link to={"/groups/" + e.id + "/polls"}>
-                <button className="btn button">{e.label}</button>
+                <button className="btn button width-20em">{e.label}</button>
               </Link>
           ))}
 

--- a/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
+++ b/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
@@ -11,8 +11,8 @@ export default class Groups extends Component {
       error: null,
       doneLoading: false,
       admin_groups: [
-        {id: 123, label: "CSCI 1200 - Data Structures"},
-        {id: 123, label: "CSCI 2200 - Foundations of Computer Science"}
+        // {id: 123, label: "CSCI 1200 - Data Structures"},
+        // {id: 123, label: "CSCI 2200 - Foundations of Computer Science"}
       ],
       member_groups: [
         {id: 123, label: "CSCI 2300 - Intro to Algorithms"},
@@ -67,7 +67,7 @@ export default class Groups extends Component {
               As a Group Admin:
             </p>
             {this.state.admin_groups.length === 0 ? (
-              <p>Sorry, you are not the admin of any groups.<br/> <br/> <br/></p>
+              <p>Sorry, you are not the admin of any groups.<br/> <br/></p>
             ) : (
               <React.Fragment>
                 {this.state.admin_groups.map((e) => (
@@ -82,7 +82,7 @@ export default class Groups extends Component {
               As a Group Member:
             </p>
             {this.state.member_groups.length === 0 ? (
-              <p>Sorry, you are not the member of any groups.<br/> <br/> <br/></p>
+              <p>Sorry, you are not the member of any groups.<br/> <br/></p>
             ) : (
               <React.Fragment>
                 {this.state.member_groups.map((e) => (

--- a/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
+++ b/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
@@ -1,32 +1,24 @@
 import React, {Component} from "react";
-import {Link, Redirect} from "react-router-dom";
+import {Link } from "react-router-dom";
 import { MDBContainer } from "mdbreact";
 import LoadingWheel from "../../components/LoadingWheel/LoadingWheel";
-
-function getGroups(){
-  return [
-    {key: 0, id: 123, label: "CSCI 2300 - Intro to Algorithms"},
-    {key: 1, id: 123, label: "CSCI 2500 - Computer Organization"},
-    {key: 2, id: 123, label: "CSCI 2960 - RCOS"}
-  ]
-}
 
 export default class Groups extends Component {
   constructor(){
     super();
     this.state = {
+      //TODO: fetch this data from api/users/:id/groups when that functionality works
       error: null,
       doneLoading: false,
       admin_groups: [
-        {key: 0, id: 123, label: "CSCI 1200 - Data Structures"},
-        {key: 1, id: 123, label: "CSCI 2200 - Foundations of Computer Science"}
+        {id: 123, label: "CSCI 1200 - Data Structures"},
+        {id: 123, label: "CSCI 2200 - Foundations of Computer Science"}
       ],
       member_groups: [
-        {key: 0, id: 123, label: "CSCI 2300 - Intro to Algorithms"},
-        {key: 1, id: 123, label: "CSCI 2500 - Computer Organization"},
-        {key: 2, id: 123, label: "CSCI 2960 - RCOS"}
-      ],
-      all_groups: getGroups()
+        {id: 123, label: "CSCI 2300 - Intro to Algorithms"},
+        {id: 123, label: "CSCI 2500 - Computer Organization"},
+        {id: 123, label: "CSCI 2960 - RCOS"}
+      ]
     };
 
     if(!localStorage.getItem("loggedIn")){
@@ -47,8 +39,8 @@ export default class Groups extends Component {
   }
   componentDidMount(){
     this.props.updateTitle("My Groups");
-
   }
+
   render() {
     if(this.state.error != null){
       return <p className="fontSizeLarge">Error! Please try again.</p>
@@ -68,20 +60,32 @@ export default class Groups extends Component {
             <p className="fontSizeLarge">
               As a Group Admin:
             </p>
-            {this.state.admin_groups.map((e) => (
-                <Link to={"/groups/" + e.id + "/polls"}>
-                  <button className="btn button width-20em">{e.label}</button>
-                </Link>
-            ))}
+            {this.state.admin_groups.length === 0 ? (
+              <p>Sorry, you are not the admin of any groups.</p>
+            ) : (
+              <MDBContainer className="box">
+                {this.state.admin_groups.map((e) => (
+                  <Link to={"/groups/" + e.id + "/polls"}>
+                    <button className="btn button width-20em">{e.label}</button>
+                  </Link>
+                ))}
+              </MDBContainer>
+            )}
 
             <p className="fontSizeLarge">
               As a Group Member:
             </p>
-            {this.state.member_groups.map((e) => (
-                <Link to={"/groups/" + e.id + "/polls"}>
-                  <button className="btn button width-20em">{e.label}</button>
-                </Link>
-            ))}
+            {this.state.member_groups.length === 0 ? (
+              <p>Sorry, you are not the member of any groups.</p>
+            ) : (
+              <MDBContainer className="box">
+                {this.state.member_groups.map((e) => (
+                  <Link to={"/groups/" + e.id + "/polls"}>
+                    <button className="btn button width-20em">{e.label}</button>
+                  </Link>
+                ))}
+              </MDBContainer>
+            )}
 
             <p className="fontSizeLarge">
               Group Management:

--- a/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
+++ b/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
@@ -43,7 +43,14 @@ export default class Groups extends Component {
 
   render() {
     if(this.state.error != null){
-      return <p className="fontSizeLarge">Error! Please try again.</p>;
+      return <MDBContainer fluid className="page">
+        <MDBContainer fluid className="box">
+          <p className="fontSizeLarge">
+            Error! Please try again.
+          </p>
+        </MDBContainer>
+      </MDBContainer>
+
     } else if(!this.state.doneLoading){
       return (
         <MDBContainer>
@@ -59,30 +66,30 @@ export default class Groups extends Component {
               As a Group Admin:
             </p>
             {this.state.admin_groups.length === 0 ? (
-              <p>Sorry, you are not the admin of any groups.</p>
+              <p>Sorry, you are not the admin of any groups.<br/> <br/> <br/></p>
             ) : (
-              <MDBContainer className="box">
+              <React.Fragment>
                 {this.state.admin_groups.map((e) => (
                   <Link to={"/groups/" + e.id + "/polls"}>
                     <button className="btn button width-20em">{e.label}</button>
                   </Link>
                 ))}
-              </MDBContainer>
+              </React.Fragment>
             )}
 
             <p className="fontSizeLarge">
               As a Group Member:
             </p>
             {this.state.member_groups.length === 0 ? (
-              <p>Sorry, you are not the member of any groups.</p>
+                <p>Sorry, you are not the member of any groups.<br/> <br/> <br/></p>
             ) : (
-              <MDBContainer className="box">
+              <React.Fragment>
                 {this.state.member_groups.map((e) => (
                   <Link to={"/groups/" + e.id + "/polls"}>
                     <button className="btn button width-20em">{e.label}</button>
                   </Link>
                 ))}
-              </MDBContainer>
+              </React.Fragment>
             )}
 
             <p className="fontSizeLarge">

--- a/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
+++ b/PollBuddy-Server/frontend/src/pages/Groups/Groups.js
@@ -43,14 +43,15 @@ export default class Groups extends Component {
 
   render() {
     if(this.state.error != null){
-      return <MDBContainer fluid className="page">
-        <MDBContainer fluid className="box">
-          <p className="fontSizeLarge">
-            Error! Please try again.
-          </p>
+      return (
+        <MDBContainer fluid className="page">
+          <MDBContainer fluid className="box">
+            <p className="fontSizeLarge">
+              Error! Please try again.
+            </p>
+          </MDBContainer>
         </MDBContainer>
-      </MDBContainer>
-
+      );
     } else if(!this.state.doneLoading){
       return (
         <MDBContainer>
@@ -81,7 +82,7 @@ export default class Groups extends Component {
               As a Group Member:
             </p>
             {this.state.member_groups.length === 0 ? (
-                <p>Sorry, you are not the member of any groups.<br/> <br/> <br/></p>
+              <p>Sorry, you are not the member of any groups.<br/> <br/> <br/></p>
             ) : (
               <React.Fragment>
                 {this.state.member_groups.map((e) => (

--- a/PollBuddy-Server/frontend/src/styles/main.scss
+++ b/PollBuddy-Server/frontend/src/styles/main.scss
@@ -189,3 +189,8 @@ a:hover {
   color: var(--white-most-text);
   text-decoration: underline;
 }
+
+//for group buttons on the Groups page
+.width-20em{
+  width: 20em;
+}


### PR DESCRIPTION
<!-- Thank you for your pull request. Please fill out the items below :) -->

<!-- 
### Things to do before creating a pull request:
1. Make sure that your PR is not a duplicate.
2. You have done your changes in a separate branch that's based off of either frontend or backend.
3. You have used descriptive commit messages.
4. You've tested your changes
5. Your pull request should be from your branch into either frontend or backend. 
6. Your pull request should have a descriptive title, and fill out everything below.
7. Assign someone to review this PR, plus the PM

-->

### Description of change(s), including why:

Finished (almost all) the requirements from https://github.com/PollBuddy/PollBuddy/issues/268.

Added state variables for error, loading, and two arrays listing the groups that the user is part of. Currently, all of this is hardcoded, but when the backend api/users/:id/groups functionality works, we can fetch data from there. Using the two arrays, dynamically generates buttons (of equal width) for each group. It checks the length of each array, and if the user is not part of any groups, it displays a message. 

Currently, the loading wheel always appears, and there is a button to stop loading, which we can remove later. If there is an error, it displays a message. There is no functionality for Bounce to /login if user is not logged in


### Type of change(s)
<!--- What types of changes does your code introduce? Replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Any work to still do or other concerns:

- Should request from the backend what groups the user is a part of
- Bounce to /login if user is not logged in

### Closing issues:

- Closes #268 

### Screenshots (if frontend change) of before and after:
![groups](https://user-images.githubusercontent.com/37943727/98429212-51c31780-2073-11eb-90e6-0493ac3101bb.png)
![no member](https://user-images.githubusercontent.com/37943727/98429213-51c31780-2073-11eb-9f48-3b096e947ba6.png)
![no admin](https://user-images.githubusercontent.com/37943727/98429214-51c31780-2073-11eb-8df5-0f9fc3cf6ab4.png)
![loading](https://user-images.githubusercontent.com/37943727/98429215-525bae00-2073-11eb-9688-bb7d14b11e70.png)
![error](https://user-images.githubusercontent.com/37943727/98429217-525bae00-2073-11eb-8bbe-96319ce896e3.png)


