### PR TITLE
Footer update

### DIFF
--- a/PollBuddy-Server/frontend/src/components/Footer/Footer.js
+++ b/PollBuddy-Server/frontend/src/components/Footer/Footer.js
@@ -10,9 +10,6 @@ export default class Footer extends Component {
     return (
       <footer className = "Footer-foot">
         <MDBContainer className = "Footer-foot-links">
-          <span>&copy; 2020 Poll Buddy</span>
-        </MDBContainer>
-        <MDBContainer className = "Footer-foot-links">
           <span><a href = "/about">
             About
           </a>
@@ -28,6 +25,9 @@ export default class Footer extends Component {
           <a href = "/privacy">
             Privacy
           </a></span>
+        </MDBContainer>
+        <MDBContainer className = "Footer-foot-links Footer-copy">
+          <span>&copy; 2020 Poll Buddy</span>
         </MDBContainer>
         <MDBContainer className = "Footer-foot-links">
           <a href = "https://rcos.io/" target = "_blank" rel="noopener noreferrer">

--- a/PollBuddy-Server/frontend/src/components/Footer/Footer.js
+++ b/PollBuddy-Server/frontend/src/components/Footer/Footer.js
@@ -9,36 +9,33 @@ export default class Footer extends Component {
   render() {
     return (
       <footer className = "Footer-foot">
-        <MDBContainer className = "Footer-linethru" />
-        <MDBContainer className = "Footer-links">
-          <MDBContainer className = "Footer-foot-links">
-            &copy; 2020 Poll Buddy
-          </MDBContainer>
-          <MDBContainer className = "Footer-foot-links">
-            <a href = "/about">
-              About
-            </a>
-            <a href = "https://info.rpi.edu/statement-of-accessibility" target = "_blank" rel = "noopener noreferrer">
-              Accessibility
-            </a>
-            <a href = "/contact">
-              Contact
-            </a>
-            <a href = "/faq">
-              FAQ
-            </a>
-            <a href = "/privacy">
-              Privacy
-            </a>
-          </MDBContainer>
-          <MDBContainer className = "Footer-foot-links">
-            <a href = "https://rcos.io/" target = "_blank" rel="noopener noreferrer">
-              <img src = {rcosLogo} alt = "RCOS" />
-            </a>
-            <a href = "https://github.com/PollBuddy/PollBuddy" target = "_blank" rel="noopener noreferrer">
-              <img src = {githubLogo} alt = "Github" />
-            </a>
-          </MDBContainer>
+        <MDBContainer className = "Footer-foot-links">
+          <span>&copy; 2020 Poll Buddy</span>
+        </MDBContainer>
+        <MDBContainer className = "Footer-foot-links">
+          <span><a href = "/about">
+            About
+          </a>
+          <a href = "https://info.rpi.edu/statement-of-accessibility" target = "_blank" rel = "noopener noreferrer">
+            Accessibility
+          </a></span>
+          <span><a href = "/contact">
+            Contact
+          </a>
+          <a href = "/faq">
+            FAQ
+          </a>
+          <a href = "/privacy">
+            Privacy
+          </a></span>
+        </MDBContainer>
+        <MDBContainer className = "Footer-foot-links">
+          <a href = "https://rcos.io/" target = "_blank" rel="noopener noreferrer">
+            <img src = {rcosLogo} alt = "RCOS" />
+          </a>
+          <a href = "https://github.com/PollBuddy/PollBuddy" target = "_blank" rel="noopener noreferrer">
+            <img src = {githubLogo} alt = "Github" />
+          </a>
         </MDBContainer>
       </footer>
     );

--- a/PollBuddy-Server/frontend/src/components/Footer/Footer.scss
+++ b/PollBuddy-Server/frontend/src/components/Footer/Footer.scss
@@ -28,6 +28,9 @@
   height: var(--font-size-small);
   width: auto;
 }
+.Footer-foot-links:last-child a {
+  padding: 8px 10px !important;
+}
 @media only screen and (min-width: 762px) {
   .Footer-foot-links:last-child {
     position: absolute;
@@ -35,7 +38,7 @@
     margin-right: 20px;
   }
 }
-@media only screen and (max-width: 419px) {
+@media only screen and (max-width: 420px) {
   .Footer-foot-links span {
     display: block;
   }

--- a/PollBuddy-Server/frontend/src/components/Footer/Footer.scss
+++ b/PollBuddy-Server/frontend/src/components/Footer/Footer.scss
@@ -1,39 +1,24 @@
 .Footer-foot {
-  padding: 0 0 20px;
+  padding: 10px 20px;
   font: var(--font-size-small) / 1 var(--main-font);
   box-sizing: border-box;
   width: 100%;
   position: absolute;
   bottom: 0;
-}
-.Footer-linethru {
-  background: var(--base-purple-logo-bg);
-  width: 100%;
-  margin: calc((var(--font-size-small) - 1px) / 2) 0;
-  height: 1px;
-  position: absolute;
-  z-index: -9;
+  background: var(--darkest-purple-header-color);
+  margin-top: 50px;
 }
 .Footer-foot-links {
-  background: var(--dark-purple-main-background);
-  padding: 0px 40px;
   display: inline-block;
+  padding: 0 10px;
+  vertical-align: top;
 }
-.Footer-foot-links:first-child {
-  position: absolute;
-  left: 0;
-}
-.Footer-foot-links:last-child {
-  position: absolute;
-  right: 0;
-}
-.Footer-links {
-  text-align: center;
-  width: 100%;
+.Footer-foot a, .Footer-foot span:only-child {
+  display: inline-block;
+  padding: 10px;
 }
 .Footer-foot a {
   color: var(--white-most-text);
-  margin: 0 20px 0 0;
   opacity: 0.8;
 }
 .Footer-foot a:hover {
@@ -43,6 +28,15 @@
   height: var(--font-size-small);
   width: auto;
 }
-.Footer-foot div a:last-of-type {
-  margin: 0;
+@media only screen and (min-width: 762px) {
+  .Footer-foot-links:last-child {
+    position: absolute;
+    right: 0;
+    margin-right: 20px;
+  }
+}
+@media only screen and (max-width: 419px) {
+  .Footer-foot-links span {
+    display: block;
+  }
 }

--- a/PollBuddy-Server/frontend/src/components/Footer/Footer.scss
+++ b/PollBuddy-Server/frontend/src/components/Footer/Footer.scss
@@ -9,9 +9,7 @@
   margin-top: 50px;
 }
 .Footer-foot-links {
-  display: inline-block;
   padding: 0 10px;
-  vertical-align: top;
 }
 .Footer-foot a, .Footer-foot span:only-child {
   display: inline-block;
@@ -29,12 +27,9 @@
   width: auto;
 }
 .Footer-foot-links:last-child a {
-  padding: 8px 10px !important;
+  padding: 8px 10px;
 }
-.Footer-foot-links:first-child {
-  display: block;
-}
-.Footer-foot-links span {
+.Footer-foot-links:first-child, .Footer-foot-links span {
   display: block;
 }
 @media only screen and (min-width: 762px) {
@@ -51,5 +46,9 @@
 @media only screen and (min-width: 420px) {
   .Footer-foot-links span {
     display: inline;
+  }
+  .Footer-foot-links {
+    display: inline-block;
+    vertical-align: top;
   }
 }

--- a/PollBuddy-Server/frontend/src/components/Footer/Footer.scss
+++ b/PollBuddy-Server/frontend/src/components/Footer/Footer.scss
@@ -31,15 +31,25 @@
 .Footer-foot-links:last-child a {
   padding: 8px 10px !important;
 }
+.Footer-foot-links:first-child {
+  display: block;
+}
+.Footer-foot-links span {
+  display: block;
+}
 @media only screen and (min-width: 762px) {
   .Footer-foot-links:last-child {
-    position: absolute;
-    right: 0;
-    margin-right: 20px;
+    float: right;
+  }
+  .Footer-copy {
+    float: left;
+  }
+  .Footer-foot-links:first-child {
+    display: inline-block;
   }
 }
-@media only screen and (max-width: 420px) {
+@media only screen and (min-width: 420px) {
   .Footer-foot-links span {
-    display: block;
+    display: inline;
   }
 }

--- a/PollBuddy-Server/frontend/src/pages/Homepage/Homepage.js
+++ b/PollBuddy-Server/frontend/src/pages/Homepage/Homepage.js
@@ -30,7 +30,7 @@ export default class Homepage extends Component {
 
   submitCode() {
     // set error message if input is invalid
-    this.setState({errMsg:
+    this.setState({errMsg: 
       !this.state.valid ? "Code must be 6 characters, A-Z, 0-9" : ""});
   }
 
@@ -55,7 +55,7 @@ export default class Homepage extends Component {
           <MDBContainer className="box">
             <MDBContainer className="form-group">
               <label htmlFor="pollCodeText">Already have a Poll Code? Enter it here:</label>
-              <input placeholder="P8C0D3" onChange={this.handleCodeChange} className="form-control textBox"/>
+              <input placeholder="K30SW8" onChange={this.handleCodeChange} className="form-control textBox"/>
               <p style={{color: "red", textAlign: "center"}}>{this.state.errMsg}</p>
             </MDBContainer>
             <Link to={this.state.valid ? "/poll/" + this.state.code + "/view" : ""}>

--- a/PollBuddy-Server/frontend/src/pages/Homepage/Homepage.js
+++ b/PollBuddy-Server/frontend/src/pages/Homepage/Homepage.js
@@ -30,7 +30,7 @@ export default class Homepage extends Component {
 
   submitCode() {
     // set error message if input is invalid
-    this.setState({errMsg: 
+    this.setState({errMsg:
       !this.state.valid ? "Code must be 6 characters, A-Z, 0-9" : ""});
   }
 
@@ -55,7 +55,7 @@ export default class Homepage extends Component {
           <MDBContainer className="box">
             <MDBContainer className="form-group">
               <label htmlFor="pollCodeText">Already have a Poll Code? Enter it here:</label>
-              <input placeholder="K30SW8" onChange={this.handleCodeChange} className="form-control textBox"/>
+              <input placeholder="P8C0D3" onChange={this.handleCodeChange} className="form-control textBox"/>
               <p style={{color: "red", textAlign: "center"}}>{this.state.errMsg}</p>
             </MDBContainer>
             <Link to={this.state.valid ? "/poll/" + this.state.code + "/view" : ""}>

--- a/PollBuddy-Server/frontend/src/styles/main.scss
+++ b/PollBuddy-Server/frontend/src/styles/main.scss
@@ -16,6 +16,29 @@
   --font-size-small: 1rem;
   --line-height: 1.2;
   --default-transition: all 0.2s ease-in-out;
+
+
+  // header + footer heights + margin to make calculating page height easier
+  --header-height: calc(var(--head-font-size) + 40px);
+  --footer-height: calc(4 * (var(--font-size-small) + 20px) + 20px);
+}
+
+@media only screen and (min-width: 383px) {
+  :root {
+    --footer-height: calc(3 * (var(--font-size-small) + 20px) + 20px);
+  }
+}
+
+@media only screen and (min-width: 420px) {
+  :root {
+    --footer-height: calc(2 * (var(--font-size-small) + 20px) + 20px);
+  }
+}
+
+@media only screen and (min-width: 762px) {
+  :root {
+    --footer-height: calc(var(--font-size-small) + 20px + 20px);
+  }
 }
 
 #wrapper {
@@ -29,8 +52,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding-bottom: calc(50px + var(--font-size-small) + 40px);
-  min-height: calc(100vh - var(--head-font-size) - 40px - var(--font-size-small) - 40px - 100px);
+  padding-bottom: calc(50px + var(--footer-height));
+  min-height: calc(100vh - var(--header-height) - var(--footer-height) - 100px);
 }
 
 h1, .fontSizeLarge {

--- a/PollBuddy-Server/frontend/src/styles/main.scss
+++ b/PollBuddy-Server/frontend/src/styles/main.scss
@@ -29,8 +29,8 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding-bottom: calc(var(--font-size-small) + 70px);
-  min-height: calc(100vh - var(--head-font-size) - var(--font-size-small) - 160px);
+  padding-bottom: calc(50px + var(--font-size-small) + 40px);
+  min-height: calc(100vh - var(--head-font-size) - 40px - var(--font-size-small) - 40px - 100px);
 }
 
 h1, .fontSizeLarge {

--- a/PollBuddy-Server/frontend/src/styles/main.scss
+++ b/PollBuddy-Server/frontend/src/styles/main.scss
@@ -23,12 +23,6 @@
   --footer-height: calc(4 * (var(--font-size-small) + 20px) + 20px);
 }
 
-@media only screen and (min-width: 383px) {
-  :root {
-    --footer-height: calc(3 * (var(--font-size-small) + 20px) + 20px);
-  }
-}
-
 @media only screen and (min-width: 420px) {
   :root {
     --footer-height: calc(2 * (var(--font-size-small) + 20px) + 20px);


### PR DESCRIPTION
<!-- Thank you for your pull request. Please fill out the items below :) -->

<!-- 
### Things to do before creating a pull request:
1. Make sure that your PR is not a duplicate.
2. You have done your changes in a separate branch that's based off of either frontend or backend.
3. You have used descriptive commit messages.
4. You've tested your changes
5. Your pull request should be from your branch into either frontend or backend. 
6. Your pull request should have a descriptive title, and fill out everything below.
7. Assign someone to review this PR, plus the PM

-->

### Description of change(s), including why:

- restyled footer to accommodate for mobile
- footer no longer overlaps (see issue 250)
- added breakpoints for different "versions" of footer
- updated wrapper/page sizing to account for footer height at each breakpoint
- breakpoints are where footer starts to wrap (these breakpoints will probably only be for the footer since device sizes will most likely be used for media queries in regards to boxed content)
- decided against using popular device sizes because wrapping looks strange for in-between sizes

### Type of change(s)
<!--- What types of changes does your code introduce? Replace the space with an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Any work to still do or other concerns:

- (none)

### Closing issues:

- Closes #250 

### Screenshots (if frontend change) of before and after:
- computer
![1](https://user-images.githubusercontent.com/31863368/99043526-606e6a80-255c-11eb-90f9-b965958980a7.png)

- mobile in portrait mode
![4](https://user-images.githubusercontent.com/31863368/99043559-69f7d280-255c-11eb-9f11-4b9a799a09de.png)

- mobile in landscape mode
![2](https://user-images.githubusercontent.com/31863368/99043614-78de8500-255c-11eb-897d-db41587ec91d.png)


