### PR TITLE
ResetPassword now reads resetcode from URL

### DIFF
--- a/PollBuddy-Server/frontend/src/pages/ResetPassword/ResetPassword.js
+++ b/PollBuddy-Server/frontend/src/pages/ResetPassword/ResetPassword.js
@@ -1,10 +1,27 @@
 import React, {Component} from "react";
 import {MDBContainer} from "mdbreact";
-import {Link} from "react-router-dom";
+import {Link, withRouter} from "react-router-dom";
+
 
 import "mdbreact/dist/css/mdb.css";
 
-export default class ResetPassword extends Component {
+class ResetPassword extends Component {
+  constructor(props) {
+    super(props);
+
+    if(this.props.location.search) {
+      var resetCode = new URLSearchParams(this.props.location.search).get("resetCode");
+      var resetCodePrefilled = true;
+
+      if(resetCode == null) {resetCode = ""; resetCodePrefilled = false; }
+    }
+
+    this.state = {
+      resetCode: resetCode,
+      resetCodePrefilled: resetCodePrefilled,
+    };
+
+  }
 
   componentDidMount() {
     this.props.updateTitle("Reset Password");
@@ -19,7 +36,8 @@ export default class ResetPassword extends Component {
           </p>
           <MDBContainer className="form-group">
             <label htmlFor="securityCodeText">Security code:</label>
-            <input placeholder="A9EM3FL8W" className="form-control textBox" id="securityCodeText"/>
+            <input placeholder="A9EM3FL8W" className="form-control textBox" id="securityCodeText"
+              value = {this.state.resetCode} readOnly={this.state.resetCodePrefilled}/>
             <label htmlFor="newPasswordText">New password:</label>
             <input type="password" placeholder="••••••••••••" className="form-control textBox" id="newPasswordText"/>
             <label htmlFor="confirmPasswordText">Confirm password:</label>
@@ -34,3 +52,5 @@ export default class ResetPassword extends Component {
     );
   }
 }
+
+export default withRouter(ResetPassword);

--- a/PollBuddy-Server/frontend/src/pages/ResetPassword/ResetPassword.js
+++ b/PollBuddy-Server/frontend/src/pages/ResetPassword/ResetPassword.js
@@ -10,7 +10,7 @@ class ResetPassword extends Component {
     super(props);
 
     if(this.props.location.search) {
-      var resetCode = new URLSearchParams(this.props.location.search).get("resetCode");
+      var resetCode = new URLSearchParams(this.props.location.search).get("resetcode");
       var resetCodePrefilled = true;
 
       if(resetCode == null) {resetCode = ""; resetCodePrefilled = false; }


### PR DESCRIPTION
<!-- Thank you for your pull request. Please fill out the items below :) -->

<!-- 
### Things to do before creating a pull request:
1. Make sure that your PR is not a duplicate.
2. You have done your changes in a separate branch that's based off of either frontend or backend.
3. You have used descriptive commit messages.
4. You've tested your changes
5. Your pull request should be from your branch into either frontend or backend. 
6. Your pull request should have a descriptive title, and fill out everything below.
7. Assign someone to review this PR, plus the PM

-->

### Description of change(s), including why:

Updated the ResetPassword page to automatically read the Security Code from a URL Parameter, which is sent in the parameter resetcode. This was done to make it easier on users, rather than having to copy the code themselves from their email, now it is auto-filled. 

### Type of change(s)
<!--- What types of changes does your code introduce? Replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Any work to still do or other concerns:

- This only reads the code from a URL Parameter, so the email that is sent for password reset would need a link that includes the resetcode in its search parameters.

### Closing issues:

- Closes #185 

### Screenshots (if frontend change) of before and after:

Before:
![autofillResetCodeBefore](https://user-images.githubusercontent.com/40744846/123457761-4268ee00-d5b2-11eb-8008-c85945a3e618.JPG)

After:
![autofillResetCodeAfter](https://user-images.githubusercontent.com/40744846/123482022-95eb3400-d5d2-11eb-94fb-97d7afbb99cd.JPG)


