### PR TITLE
Added Dynamic Header Dropdown Menu

### DIFF
--- a/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
+++ b/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
@@ -37,6 +37,9 @@ function useOutsideAlerter(ref, menuProps) {
     if(localStorage.getItem("loggedIn") == "true") {
       document.getElementById("logout").addEventListener("click",function(e) {
         e.stopPropagation();
+        fetch(process.env.REACT_APP_BACKEND_URL + "/users/logout", {
+          method: "GET"
+        }); 
         localStorage.setItem("loggedIn",false);
       });
     }

--- a/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
+++ b/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
@@ -33,6 +33,13 @@ function useOutsideAlerter(ref, menuProps) {
     }
     // Bind the event listener
     document.addEventListener("click", handleClickOutside);
+    // Stop propogation to Logout (so we don't log out every menu click) only if logged in
+    if(localStorage.getItem("loggedIn") == "true") {
+      document.getElementById("logout").addEventListener("click",function(e) {
+        e.stopPropagation();
+        localStorage.setItem("loggedIn",false);
+      });
+    }
     return () => {
       // Unbind the event listener on clean up
       document.removeEventListener("click", handleClickOutside);
@@ -40,38 +47,40 @@ function useOutsideAlerter(ref, menuProps) {
   }, [ref]);
 }
 
-function LoggedInMenu() {
+function LoggedInMenu(props) {
   const wrapperRef = useRef(null);
+  useOutsideAlerter(wrapperRef, props);
   return (
-    <div className = "Dropdown" ref = {wrapperRef}>
-      <a onClick={localStorage.setItem("loggedIn",false)} href="/">Logout</a>
+    <div className = "Dropdown" ref={wrapperRef}>
       <a href="/account">Account</a>
+      <a href="/code">Enter Poll Code</a>
       <a href="/groups">Groups</a>
       <a href="polls/history">History</a>
-      <a href="/">Settings</a>
-    </div>
+      <a href="/">Settings</a> 
+      <a href="/" id="logout">Logout</a>
+    </div> // settings page will probably be the account info page which will have to be renamed "Account Settings"
   );
 }
 
-function LoggedOutMenu() {
+function LoggedOutMenu(props) {
   const wrapperRef = useRef(null);
+  useOutsideAlerter(wrapperRef, props);
   return (
     <div className = "Dropdown" ref={wrapperRef}>
       <a href="/login">Login</a>
       <a href="/register">Register</a>
+      <a href="/code">Enter Poll Code</a>
     </div>
   );
 }
 
 function DropdownMenu(props) {
   console.log("Status: " + localStorage.getItem("loggedIn"))
-  const wrapperRef = useRef(null);
-  useOutsideAlerter(wrapperRef, props);
   if(localStorage.getItem("loggedIn") == "true") {
-    return <LoggedInMenu />
+    return LoggedInMenu(props);
   }
   else {
-    return <LoggedOutMenu />
+    return LoggedOutMenu(props);
   }
   // return (
   //   <div className="Dropdown" ref={wrapperRef}>

--- a/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
+++ b/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
@@ -35,27 +35,29 @@ function useOutsideAlerter(ref, menuProps) {
     }
     // Bind the event listener
     document.addEventListener("click", handleClickOutside);
-    // Stop propogation to Logout (so we don't log out every menu click) only if logged in
+    // Stop propagation to Logout (so we don't log out every menu click) only if logged in
     if(localStorage.getItem("loggedIn") === "true") {
       document.getElementById("logout").addEventListener("click",function(e) {
         e.stopPropagation();
         fetch(process.env.REACT_APP_BACKEND_URL + "/users/logout", {
           method: "GET"
-        }).then(response => {
-          if(response.ok) {
-            //Logout has succeeded, Clear frontend user data
-            localStorage.setItem("loggedIn",false);
-            localStorage.removeItem("lastName");
-            localStorage.removeItem("userName");
-            localStorage.removeItem("firstName");
-          } else {
-            console.log("Error Logging Out");
-          }
-          //Navigates after response so that the redirect does not interrupt response
-          history.push('/');
-          //Reloads the page so that the logged-in menu closes
-          history.go(0);
-        });
+        }).then(response => response.json())
+          .then(response => {
+            console.log(response);
+            if(response.result === "success") {
+              //Logout has succeeded, Clear frontend user data
+              localStorage.setItem("loggedIn", false);
+              localStorage.removeItem("lastName");
+              localStorage.removeItem("userName");
+              localStorage.removeItem("firstName");
+            } else {
+              console.log("Error Logging Out");
+            }
+            //Navigates after response so that the redirect does not interrupt response
+            history.push("/");
+            //Reloads the page so that the logged-in menu closes
+            history.go(0);
+          });
       });
     }
     return () => {

--- a/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
+++ b/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
@@ -1,6 +1,7 @@
 import React, { Component, useState, useRef, useEffect } from "react";
 import "mdbreact/dist/css/mdb.css";
 import "./Dropdown.scss";
+import { useHistory } from "react-router-dom";
 
 export default class Dropdown extends Component {
   render() {
@@ -24,6 +25,7 @@ function DropdownButton() {
 }
 
 function useOutsideAlerter(ref, menuProps) {
+  let history = useHistory();
   useEffect(() => {
     // Close menu if click outside
     function handleClickOutside(event) {
@@ -34,16 +36,26 @@ function useOutsideAlerter(ref, menuProps) {
     // Bind the event listener
     document.addEventListener("click", handleClickOutside);
     // Stop propogation to Logout (so we don't log out every menu click) only if logged in
-    if(localStorage.getItem("loggedIn") == "true") {
+    if(localStorage.getItem("loggedIn") === "true") {
       document.getElementById("logout").addEventListener("click",function(e) {
         e.stopPropagation();
         fetch(process.env.REACT_APP_BACKEND_URL + "/users/logout", {
           method: "GET"
-        }); 
-        localStorage.setItem("loggedIn",false);
-        localStorage.removeItem("lastName");
-        localStorage.removeItem("userName");
-        localStorage.removeItem("firstName");
+        }).then(response => {
+            if(response.ok) {
+              //Logout has succeeded, Clear frontend user data
+              localStorage.setItem("loggedIn",false);
+              localStorage.removeItem("lastName");
+              localStorage.removeItem("userName");
+              localStorage.removeItem("firstName");
+            } else {
+              console.log("Error Logging Out");
+            }
+            //Navigates after response so that the redirect does not interrupt response
+            history.push('/');
+            //Reloads the page so that the logged-in menu closes
+            history.go(0);
+        });
       });
     }
     return () => {
@@ -63,7 +75,7 @@ function LoggedInMenu(props) {
       <a href="/groups">Groups</a>
       <a href="polls/history">History</a>
       <a href="/">Settings</a> 
-      <a href="/" id="logout">Logout</a>
+      <a id="logout">Logout</a>
     </div> // settings page will probably be the account info page which will have to be renamed "Account Settings"
     //History currently directs to the same place as My Poll History Page in App.js
     //Settings seems to no longer be used, seems covered by Account, as described by old comment above
@@ -83,7 +95,7 @@ function LoggedOutMenu(props) {
 }
 
 function DropdownMenu(props) {
-  if(localStorage.getItem("loggedIn") == "true") {
+  if(localStorage.getItem("loggedIn") === "true") {
     return LoggedInMenu(props);
   } else {
     return LoggedOutMenu(props);

--- a/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
+++ b/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
@@ -74,11 +74,9 @@ function LoggedInMenu(props) {
       <a href="/code">Enter Poll Code</a>
       <a href="/groups">Groups</a>
       <a href="polls/history">History</a>
-      <a href="/">Settings</a> 
-      <a id="logout">Logout</a>
-    </div> // settings page will probably be the account info page which will have to be renamed "Account Settings"
-    //History currently directs to the same place as My Poll History Page in App.js
-    //Settings seems to no longer be used, seems covered by Account, as described by old comment above
+      <a id="logout">Logout</a> 
+    </div>
+    //Logout routes to '/' in the event listeners above
   );
 }
 

--- a/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
+++ b/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
@@ -41,23 +41,28 @@ function useOutsideAlerter(ref, menuProps) {
         e.stopPropagation();
         fetch(process.env.REACT_APP_BACKEND_URL + "/users/logout", {
           method: "GET"
-        }).then(response => response.json())
-          .then(response => {
-            console.log(response);
-            if(response.result === "success") {
-              //Logout has succeeded, Clear frontend user data
-              localStorage.setItem("loggedIn", false);
-              localStorage.removeItem("lastName");
-              localStorage.removeItem("userName");
-              localStorage.removeItem("firstName");
-            } else {
-              console.log("Error Logging Out");
-            }
-            //Navigates after response so that the redirect does not interrupt response
-            history.push("/");
-            //Reloads the page so that the logged-in menu closes
-            history.go(0);
-          });
+        }).then(response => {
+          if(response.ok) {
+            return response.json();
+          } else {
+            console.log("Error Logging Out");
+          }
+        }).then(response => {
+          console.log(response);
+          if(response.result === "success") {
+            //Logout has succeeded, Clear frontend user data
+            localStorage.setItem("loggedIn", false);
+            localStorage.removeItem("lastName");
+            localStorage.removeItem("userName");
+            localStorage.removeItem("firstName");
+          } else {
+            console.log("Error Logging Out");
+          }
+          //Navigates after response so that the redirect does not interrupt response
+          history.push("/");
+          //Reloads the page so that the logged-in menu closes
+          history.go(0);
+        });
       });
     }
     return () => {

--- a/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
+++ b/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
@@ -40,19 +40,49 @@ function useOutsideAlerter(ref, menuProps) {
   }, [ref]);
 }
 
-function DropdownMenu(props) {
+function LoggedInMenu() {
   const wrapperRef = useRef(null);
-  useOutsideAlerter(wrapperRef, props);
   return (
-    <div className="Dropdown" ref={wrapperRef}>
-      <a href="/login">Login</a>
-      <a onClick={localStorage.setItem("loggedIn", false)} href="/">Logout</a>
-      <a href="/register">Register</a>
+    <div className = "Dropdown" ref = {wrapperRef}>
+      <a onClick={localStorage.setItem("loggedIn",false)} href="/">Logout</a>
       <a href="/account">Account</a>
       <a href="/groups">Groups</a>
-      <a href="/polls/history">History</a>
-      <a href="/code">Enter Poll Code</a>
-      {/* <a href="/">Settings</a> */}
+      <a href="polls/history">History</a>
+      <a href="/">Settings</a>
     </div>
-  ); // settings page will probably be the account info page which will have to be renamed "Account Settings"
+  );
+}
+
+function LoggedOutMenu() {
+  const wrapperRef = useRef(null);
+  return (
+    <div className = "Dropdown" ref={wrapperRef}>
+      <a href="/login">Login</a>
+      <a href="/register">Register</a>
+    </div>
+  );
+}
+
+function DropdownMenu(props) {
+  console.log("Status: " + localStorage.getItem("loggedIn"))
+  const wrapperRef = useRef(null);
+  useOutsideAlerter(wrapperRef, props);
+  if(localStorage.getItem("loggedIn") == "true") {
+    return <LoggedInMenu />
+  }
+  else {
+    return <LoggedOutMenu />
+  }
+  // return (
+  //   <div className="Dropdown" ref={wrapperRef}>
+  //     <a href="/login">Login</a>
+  //     <a onClick={localStorage.setItem("loggedIn", false)} href="/">Logout</a>
+  //     <a href="/register">Register</a>
+  //     <a href="/account">Account</a>
+  //     <a href="/groups">Groups</a>
+  //     <a href="/polls/history">History</a>
+  //     <a href="/code">Enter Poll Code</a>
+  //     {/* <a href="/">Settings</a> */}
+  //   </div>
+  // ); // settings page will probably be the account info page which will have to be renamed "Account Settings"
 }

--- a/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
+++ b/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
@@ -59,6 +59,8 @@ function LoggedInMenu(props) {
       <a href="/">Settings</a> 
       <a href="/" id="logout">Logout</a>
     </div> // settings page will probably be the account info page which will have to be renamed "Account Settings"
+    //History currently directs to the same place as My Poll History Page in App.js
+    //Settings seems to no longer be used, seems covered by Account, as described by old comment above
   );
 }
 
@@ -75,23 +77,9 @@ function LoggedOutMenu(props) {
 }
 
 function DropdownMenu(props) {
-  console.log("Status: " + localStorage.getItem("loggedIn"))
   if(localStorage.getItem("loggedIn") == "true") {
     return LoggedInMenu(props);
-  }
-  else {
+  } else {
     return LoggedOutMenu(props);
   }
-  // return (
-  //   <div className="Dropdown" ref={wrapperRef}>
-  //     <a href="/login">Login</a>
-  //     <a onClick={localStorage.setItem("loggedIn", false)} href="/">Logout</a>
-  //     <a href="/register">Register</a>
-  //     <a href="/account">Account</a>
-  //     <a href="/groups">Groups</a>
-  //     <a href="/polls/history">History</a>
-  //     <a href="/code">Enter Poll Code</a>
-  //     {/* <a href="/">Settings</a> */}
-  //   </div>
-  // ); // settings page will probably be the account info page which will have to be renamed "Account Settings"
 }

--- a/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
+++ b/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
@@ -42,19 +42,19 @@ function useOutsideAlerter(ref, menuProps) {
         fetch(process.env.REACT_APP_BACKEND_URL + "/users/logout", {
           method: "GET"
         }).then(response => {
-            if(response.ok) {
-              //Logout has succeeded, Clear frontend user data
-              localStorage.setItem("loggedIn",false);
-              localStorage.removeItem("lastName");
-              localStorage.removeItem("userName");
-              localStorage.removeItem("firstName");
-            } else {
-              console.log("Error Logging Out");
-            }
-            //Navigates after response so that the redirect does not interrupt response
-            history.push('/');
-            //Reloads the page so that the logged-in menu closes
-            history.go(0);
+          if(response.ok) {
+            //Logout has succeeded, Clear frontend user data
+            localStorage.setItem("loggedIn",false);
+            localStorage.removeItem("lastName");
+            localStorage.removeItem("userName");
+            localStorage.removeItem("firstName");
+          } else {
+            console.log("Error Logging Out");
+          }
+          //Navigates after response so that the redirect does not interrupt response
+          history.push('/');
+          //Reloads the page so that the logged-in menu closes
+          history.go(0);
         });
       });
     }

--- a/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
+++ b/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.js
@@ -41,6 +41,9 @@ function useOutsideAlerter(ref, menuProps) {
           method: "GET"
         }); 
         localStorage.setItem("loggedIn",false);
+        localStorage.removeItem("lastName");
+        localStorage.removeItem("userName");
+        localStorage.removeItem("firstName");
       });
     }
     return () => {

--- a/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.scss
+++ b/PollBuddy-Server/frontend/src/components/Dropdown/Dropdown.scss
@@ -27,3 +27,11 @@
   float: right;
   margin: calc((var(--header-inner-height) - var(--font-size-small) * var(--line-height) - 24px) / 2) 0 0 0 !important;
 }
+
+#logout {
+  color: var(--light-purple-logo-text);
+}
+
+#logout:hover {
+  color: var(--white-most-text);
+}


### PR DESCRIPTION
<!-- Thank you for your pull request. Please fill out the items below :) -->

<!-- 
### Things to do before creating a pull request:
1. Make sure that your PR is not a duplicate.
2. You have done your changes in a separate branch that's based off of either frontend or backend.
3. You have used descriptive commit messages.
4. You've tested your changes
5. Your pull request should be from your branch into either frontend or backend. 
6. Your pull request should have a descriptive title, and fill out everything below.
7. Assign someone to review this PR, plus the PM

-->

### Description of change(s), including why:

Adjusted the Menu in the header to display Login, Register, and Enter Poll Code when loggedIn in localStorage is false, and Account, Enter Poll Code, Groups, History, Settings, and Logout when loggedIn in localStorage is true. This way the menu will only display ways to log in (as well as the poll code entry) if a user is not logged in, and allow user to access the pages that require them to be logged in if they have logged in. Done in a response to Issue #174.

### Type of change(s)
<!--- What types of changes does your code introduce? Replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Any work to still do or other concerns:

- In the issue this is based on (#174), it is also specified that we "Make sure each menu item links to the correct path". All options link to working paths except History and Settings. For History, I just linked it to the same page as in App.js, which is currently an error screen. I was not sure where Settings should go, but due to the age of the issue, I suspect this is no longer used?

### Closing issues:

- Closes #XXXX

### Screenshots (if frontend change) of before and after:
Before:
![dynamicHeaderBefore](https://user-images.githubusercontent.com/40744846/126023657-74b7901d-5421-41f3-8be0-a9266a678935.JPG)

After (Logged out):
![dynamicHeaderAfterLoggedOut](https://user-images.githubusercontent.com/40744846/126023660-31f8102d-94a8-43d3-ae9f-ecbfb872766b.JPG)

After (Logged in):
![dynamicHeaderAfterLoggedIn](https://user-images.githubusercontent.com/40744846/126023663-37065a8d-d8dd-4ada-8ded-e62170f20c1b.JPG)


