### PR TITLE
Locked Mongo version to 4 in the dev config

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -43,7 +43,7 @@ services:
       - backend
   
   db:
-    image: "mongo:latest"
+    image: "mongo:4"
     restart: unless-stopped
     volumes:
       - mongodata:/data/db


### PR DESCRIPTION
<!-- Thank you for your pull request. Please fill out the items below :) -->

<!-- 
### Things to do before creating a pull request:
1. Make sure that your PR is not a duplicate.
2. You have done your changes in a separate branch that's based on either frontend or backend.
3. You have used descriptive commit messages.
4. You have tested your changes.
5. Your pull request should be from your branch into either frontend or backend. 
6. Your pull request should have a descriptive title, and fill out everything below.
7. Your code should either include proper documentation or leave it as a Todo item and open an issue with label `documentation`.
8. Assign someone to review this PR, plus the PM.

-->

### Description of change(s), including why:

Fix for #527:

> A while back, we found a bug where Mongo would fail to start with no error logs or anything, so a fix was implemented (a453b22), but apparently I didn't do it for the dev version... Now I'm seeing version conflict issues where one doesn't want to start with the other's DB. I should have locked them both

Now, I have.

### Type of change(s)
<!--- What types of changes does your code introduce? Replace the space with an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Any work to still do or other concerns:

- (none)

### Closing issues:

- Closes #527

### Screenshots (if frontend change) of before and after:


