### PR TITLE
Added a back to group button

### DIFF
--- a/PollBuddy-Server/frontend/src/pages/PollEditor/PollEditor.js
+++ b/PollBuddy-Server/frontend/src/pages/PollEditor/PollEditor.js
@@ -12,6 +12,7 @@ import { purple } from '@mui/material/colors';
 import {createTheme, ThemeProvider} from "@mui/material";
 import {Link} from "react-router-dom";
 
+
 class PollEditor extends Component {
   constructor(props) {
     super(props);
@@ -28,8 +29,9 @@ class PollEditor extends Component {
       pollQuestionValue: "",
       reorderQuestions: false,
       randomQuestions: false,
-
+      
       pollID: props.router.params.pollID,
+      //groupID: props.router.params.groupID,
       doneLoading: false,
       questions: [],
       pollTitle: "",
@@ -389,6 +391,11 @@ class PollEditor extends Component {
                   >
                     Delete Poll
                   </button>
+                </div>
+                <div className={"pollButtons"}>
+                  <Link to={"/groups/"} className="button pollButton">
+                    Return to Group
+                  </Link>
                 </div>
                 <div className={"pollButtons"}>
                   <Link to={"/polls/" + this.state.pollID + "/view"} className="button pollButton">


### PR DESCRIPTION
In PollEditor, I added a back to Group button which takes you back to groups

<!-- Thank you for your pull request. Please fill out the items below :) -->

<!-- 
### Things to do before creating a pull request:
1. Make sure that your PR is not a duplicate.
2. You have done your changes in a separate branch that's based on either frontend or backend.
3. You have used descriptive commit messages.
4. You have tested your changes.
5. Your pull request should be from your branch into either frontend or backend. 
6. Your pull request should have a descriptive title, and fill out everything below.
7. Your code should either include proper documentation or leave it as a Todo item and open an issue with label `documentation`.
8. Assign someone to review this PR, plus the PM.

-->

### Description of change(s), including why:

This is issue #664, I added a go back to groups button, after a user finished editing the poll, they can click "Return to Group" 
to return to groups. 

### Type of change(s)
<!--- What types of changes does your code introduce? Replace the space with an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Any work to still do or other concerns:

Maybe instead of going back to all groups, this should just go back to current group. 
(I couldn't get it to work since it keeps giving me undefined groupID, but maybe someone else can)

### Closing issues:

- Closes #664

### Screenshots (if frontend change) of before and after:
Before:   
![image](https://user-images.githubusercontent.com/57297201/185281215-0a4d5f32-506e-4371-b5dd-a2aa23fe5d69.png)

After:  
![image](https://user-images.githubusercontent.com/57297201/185281127-f19c1aa9-b2dd-4347-8459-dd3efbfa33a3.png)



